### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/downloads/Update-MMDatabase.ps1
+++ b/downloads/Update-MMDatabase.ps1
@@ -30,7 +30,7 @@
 
     #check if the file has been updated
     Write-Verbose "Checking update service."
-    Invoke-RestMethod -uri "http://updates.maxmind.com/app/update?license_key=$license_key&md5=$hash" -OutFile "$DBPath\GeoIP.gz"
+    Invoke-RestMethod -uri "https://updates.maxmind.com/app/update?license_key=$license_key&md5=$hash" -OutFile "$DBPath\GeoIP.gz"
     
     if ((Get-ChildItem "$DBPath\GeoIP.gz").length -gt 10000) {
         Write-Verbose "Found an update."
@@ -41,7 +41,7 @@
         Remove-Item "$DBPath\GeoIP.gz"
 
         #assume that the organizational DB has been updated and pull a copy of that down as well
-        Invoke-RestMethod -uri "http://download.maxmind.com/app/download_new?edition_id=111&suffix=tar.gz&license_key=$license_key" -OutFile "$DBPath\GeoIPorg.tar.gz"
+        Invoke-RestMethod -uri "https://download.maxmind.com/app/download_new?edition_id=111&suffix=tar.gz&license_key=$license_key" -OutFile "$DBPath\GeoIPorg.tar.gz"
     
         #Extract the organizational file
         Write-Verbose "Expanding GeoIP organizational data file."
@@ -51,7 +51,7 @@
         Remove-Item "$DBPath\GeoIPorg.tar"
 
         #Pull down the city DB
-        Invoke-RestMethod -uri "http://download.maxmind.com/app/download_new?edition_id=133&suffix=tar.gz&license_key=$license_key" -OutFile "$DBPath\GeoIPcity.tar.gz"
+        Invoke-RestMethod -uri "https://download.maxmind.com/app/download_new?edition_id=133&suffix=tar.gz&license_key=$license_key" -OutFile "$DBPath\GeoIPcity.tar.gz"
     
         #Extract the city file
         Write-Verbose "Expanding GeoIP city data file."


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).